### PR TITLE
PHP 7.2 compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -33,5 +33,9 @@
         "classmap": [
             "src/lib.uuid.php"
         ]
+    },
+    "require-dev": {},
+    "scripts": {
+        "test": "php test.php"
     }
 }

--- a/src/PHPePub/Core/EPub.php
+++ b/src/PHPePub/Core/EPub.php
@@ -284,10 +284,8 @@ class EPub {
             $partCount = 0;
             $this->chapterCount++;
 
-            $oneChapter = each($chapter);
-            while ($oneChapter) {
+            foreach ($chapter as $v) {
                 /** @noinspection PhpUnusedLocalVariableInspection */
-                list($k, $v) = $oneChapter;
                 if ($this->encodeHTML === true) {
                     $v = StringHelper::encodeHtml($v);
                 }
@@ -301,8 +299,6 @@ class EPub {
                 $this->extractIdAttributes($partName, $v);
 
                 $this->opf->addItemRef($partName);
-
-                $oneChapter = each($chapter);
             }
             $partName = $name . "_1." . $extension;
             $navPoint = new NavPoint(StringHelper::decodeHtmlEntities($chapterName), $partName, $partName);

--- a/src/PHPePub/Core/EPub.php
+++ b/src/PHPePub/Core/EPub.php
@@ -285,7 +285,6 @@ class EPub {
             $this->chapterCount++;
 
             foreach ($chapter as $v) {
-                /** @noinspection PhpUnusedLocalVariableInspection */
                 if ($this->encodeHTML === true) {
                     $v = StringHelper::encodeHtml($v);
                 }

--- a/src/PHPePub/Core/EPubChapterSplitter.php
+++ b/src/PHPePub/Core/EPubChapterSplitter.php
@@ -145,9 +145,8 @@ class EPubChapterSplitter {
                         reset($domPath);
                         reset($domClonedPath);
 
+                        /** @var $v \DOMNode */
                         foreach ($domClonedPath as $v) {
-                            /** @noinspection PhpUnusedLocalVariableInspection */
-                            /** @var $v \DOMNode */
                             $newParent = $v->cloneNode(false);
                             $curParent->appendChild($newParent);
                             $curParent = $newParent;

--- a/src/PHPePub/Core/EPubChapterSplitter.php
+++ b/src/PHPePub/Core/EPubChapterSplitter.php
@@ -144,15 +144,13 @@ class EPubChapterSplitter {
                     if ($domDepth > 0) {
                         reset($domPath);
                         reset($domClonedPath);
-                        $oneDomClonedPath = each($domClonedPath);
-                        while ($oneDomClonedPath) {
+
+                        foreach ($domClonedPath as $v) {
                             /** @noinspection PhpUnusedLocalVariableInspection */
-                            list($k, $v) = $oneDomClonedPath;
                             /** @var $v \DOMNode */
                             $newParent = $v->cloneNode(false);
                             $curParent->appendChild($newParent);
                             $curParent = $newParent;
-                            $oneDomClonedPath = each($domClonedPath);
                         }
                     }
                     $curSize = strlen($xmlDoc->saveXML($curFile));

--- a/src/PHPePub/Core/Structure/Ncx.php
+++ b/src/PHPePub/Core/Structure/Ncx.php
@@ -292,8 +292,9 @@ class Ncx {
 
         if (sizeof($this->meta)) {
             foreach ($this->meta as $metaEntry) {
-                list($name, $content) = each($metaEntry);
-                $ncx .= "\t\t<meta name=\"" . $name . "\" content=\"" . $content . "\" />\n";
+                foreach ($metaEntry as $name => $content) {
+                    $ncx .= "\t\t<meta name=\"" . $name . "\" content=\"" . $content . "\" />\n";
+                }
             }
         }
 

--- a/src/PHPePub/Core/Structure/OPF/MetaValue.php
+++ b/src/PHPePub/Core/Structure/OPF/MetaValue.php
@@ -104,7 +104,7 @@ class MetaValue {
         }
 
         if ($bookVersion === EPub::BOOK_VERSION_EPUB2 && sizeof($this->opfAttr) > 0) {
-            while (list($name, $content) = each($this->opfAttr)) {
+            foreach ($this->opfAttr as $name => $content) {
                 $dc .= " opf:" . $name . "=\"" . $content . "\"";
             }
         }

--- a/src/lib.uuid.php
+++ b/src/lib.uuid.php
@@ -480,7 +480,11 @@ class UUID {
     return openssl_random_pseudo_bytes($bytes);
    case self::randMcrypt:
     /* Get the specified number of random bytes via Mcrypt. */
+    // phpcs:disable PHPCompatibility.Extensions.RemovedExtensions.mcryptDeprecatedRemoved
+    // phpcs:disable PHPCompatibility.FunctionUse.RemovedFunctions.mcrypt_create_ivDeprecatedRemoved
     return mcrypt_create_iv($bytes);
+    // phpcs:enable PHPCompatibility.FunctionUse.RemovedFunctions.mcrypt_create_ivDeprecatedRemoved
+    // phpcs:enable PHPCompatibility.Extensions.RemovedExtensions.mcryptDeprecatedRemoved
    case self::randCOM:
     /* Get the specified number of random bytes using Windows'
        randomness source via a COM object previously created by UUID::initRandom().
@@ -628,18 +632,19 @@ class UUID {
  }
 
  public static function initStorage($file = NULL) {
+  $args = func_get_args();
   if (self::$storeClass == "UUIDStorageStable") {
    try {self::$store = new UUIDStorageStable($file);}
    catch(Exception $e) {throw new UUIDStorageException("Storage class could not be instantiated with supplied arguments.", 1003, $e);}
    return;
   }
   $store = new ReflectionClass(self::$storeClass);
-  $args = func_get_args();
   try {self::$store = $store->newInstanceArgs($args);}
   catch(Exception $e) {throw new UUIDStorageException("Storage class could not be instantiated with supplied arguments.", 1003, $e);}
  }
 
  public static function registerStorage($name) {
+  $args = func_get_args();
   try {
    $store = new ReflectionClass($name);
   } catch(Exception $e) {
@@ -648,8 +653,7 @@ class UUID {
   if (array_search("UUIDStorage", $store->getInterfaceNames()) === FALSE)
    throw new UUIDStorageException("Storage class does not implement the UUIDStorage interface.", 1002);
   self::$storeClass = $name;
-  if (func_num_args() > 1) {
-   $args = func_get_args();
+  if (count($args) > 1) {
    array_shift($args);
    try {
     self::$store = $store->newInstanceArgs($args);

--- a/test.php
+++ b/test.php
@@ -1,7 +1,8 @@
-	<?php
+<?php
 
-	use com\grandt\EPub;
-	include_once("EPub.php");
+	require_once './vendor/autoload.php';
+
+	use PHPePub\Core\EPub;
 
 	error_reporting(E_ALL | E_STRICT);
 	ini_set('error_reporting', E_ALL | E_STRICT);
@@ -67,4 +68,5 @@
 		$content_start . "<h1>Epilogue</h1>\n<p>Plenty of test content</p>\n" . $content_end
 	);
 	$book->finalize();
-	$zipData = $book->sendBook("ExampleBook1_test");
+
+	$book->sendBook("ExampleBook1_test");


### PR DESCRIPTION
Hi,

I don't know if you're still actively working on PHPePub, but I found a few more instances of `each` that can be replaced with `foreach`. I figured I should contribute them towards your fork, given the work you've already done on making this library compatible with PHP 7.